### PR TITLE
feat: improve site SEO

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -3,8 +3,48 @@ import Navbar from "../components/Navbar";
 import { Analytics } from "@vercel/analytics/next";
 
 export const metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "https://soccerversebase.com"
+  ),
   title: "SoccerverseBase",
   description: "L'outil ultime pour Soccerverse",
+  keywords: [
+    "soccerverse",
+    "football",
+    "stats",
+    "analytics",
+    "outil",
+  ],
+  openGraph: {
+    title: "SoccerverseBase",
+    description: "L'outil ultime pour Soccerverse",
+    siteName: "SoccerverseBase",
+    locale: "fr_FR",
+    type: "website",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+        alt: "SoccerverseBase logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "SoccerverseBase",
+    description: "L'outil ultime pour Soccerverse",
+    images: ["/logo.png"],
+  },
+  alternates: {
+    canonical: "/",
+    languages: {
+      "fr-FR": "/fr",
+      "en-US": "/en",
+      "es-ES": "/es",
+      "it-IT": "/it",
+    },
+  },
 };
 
 export default function RootLayout({ children }) {

--- a/app/robots.js
+++ b/app/robots.js
@@ -1,0 +1,15 @@
+export default function robots() {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://soccerversebase.com";
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}
+

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,0 +1,28 @@
+export default function sitemap() {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://soccerversebase.com";
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/fr`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/en`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/es`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/it`,
+      lastModified: new Date(),
+    },
+  ];
+}
+


### PR DESCRIPTION
## Summary
- expand metadata with Open Graph, Twitter and language alternates
- generate robots.txt
- generate sitemap.xml

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7125cf438832d8ba9feec645424aa