### PR TITLE
feat: add support page with donation options

### DIFF
--- a/app/en/support/page.js
+++ b/app/en/support/page.js
@@ -1,0 +1,5 @@
+"use client";
+import SupportPage from "@/components/SupportPage";
+export default function Page() {
+  return <SupportPage lang="en" />;
+}

--- a/app/es/support/page.js
+++ b/app/es/support/page.js
@@ -1,0 +1,5 @@
+"use client";
+import SupportPage from "@/components/SupportPage";
+export default function Page() {
+  return <SupportPage lang="es" />;
+}

--- a/app/fr/support/page.js
+++ b/app/fr/support/page.js
@@ -1,0 +1,5 @@
+"use client";
+import SupportPage from "@/components/SupportPage";
+export default function Page() {
+  return <SupportPage lang="fr" />;
+}

--- a/app/it/support/page.js
+++ b/app/it/support/page.js
@@ -1,0 +1,5 @@
+"use client";
+import SupportPage from "@/components/SupportPage";
+export default function Page() {
+  return <SupportPage lang="it" />;
+}

--- a/app/ko/support/page.js
+++ b/app/ko/support/page.js
@@ -1,0 +1,5 @@
+"use client";
+import SupportPage from "@/components/SupportPage";
+export default function Page() {
+  return <SupportPage lang="ko" />;
+}

--- a/app/support/page.js
+++ b/app/support/page.js
@@ -1,0 +1,5 @@
+"use client";
+import SupportPage from "@/components/SupportPage";
+export default function Page() {
+  return <SupportPage lang="fr" />;
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -21,6 +21,7 @@ const MENU_LABELS = {
         { href: "/revenus", label: "Gains joueurs" },
       ],
     },
+    { href: "/support", label: "Nous soutenir" },
   ],
   en: [
     { href: "/comment-debuter", label: "Getting started" },
@@ -35,6 +36,7 @@ const MENU_LABELS = {
         { href: "/revenus", label: "Player earnings" },
       ],
     },
+    { href: "/support", label: "Support us" },
   ],
   it: [
     { href: "/comment-debuter", label: "Come iniziare" },
@@ -49,6 +51,7 @@ const MENU_LABELS = {
         { href: "/revenus", label: "Guadagni giocatori" },
       ],
     },
+    { href: "/support", label: "Sostienici" },
   ],
   es: [
     { href: "/comment-debuter", label: "Cómo empezar" },
@@ -63,6 +66,7 @@ const MENU_LABELS = {
         { href: "/revenus", label: "Ganancias jugadores" },
       ],
     },
+    { href: "/support", label: "Apóyanos" },
   ],
   ko: [
     { href: "/comment-debuter", label: "시작하기" },
@@ -77,6 +81,7 @@ const MENU_LABELS = {
         { href: "/revenus", label: "선수 수익" },
       ],
     },
+    { href: "/support", label: "후원하기" },
   ],
 };
 

--- a/components/SupportPage.js
+++ b/components/SupportPage.js
@@ -1,0 +1,71 @@
+"use client";
+import Image from "next/image";
+
+const LABELS = {
+  fr: {
+    title: "Nous soutenir",
+    usdcTitle: "Envoyer des USDC (Polygon)",
+    usdcAddress: "Adresse : 0x6CB18B7c29f84f28fA510aFFBE0fd00EFCE5e105",
+    usdcNote: "Scanne ce QR code pour envoyer des USDC.",
+    svcTitle: "Envoyer des SVC en jeu",
+    svcDesc: "Compte : klo (attention, tout en minuscule)",
+    svcNote: "Tu peux envoyer des SVC directement en jeu sur le compte \"klo\".",
+  },
+  en: {
+    title: "Support us",
+    usdcTitle: "Send USDC (Polygon)",
+    usdcAddress: "Address: 0x6CB18B7c29f84f28fA510aFFBE0fd00EFCE5e105",
+    usdcNote: "Scan this QR code to send USDC.",
+    svcTitle: "Send in-game SVC",
+    svcDesc: "Account: klo (all lowercase)",
+    svcNote: "You can send SVC in game to the account \"klo\".",
+  },
+  es: {
+    title: "Apóyanos",
+    usdcTitle: "Enviar USDC (Polygon)",
+    usdcAddress: "Dirección: 0x6CB18B7c29f84f28fA510aFFBE0fd00EFCE5e105",
+    usdcNote: "Escanea este código QR para enviar USDC.",
+    svcTitle: "Enviar SVC en el juego",
+    svcDesc: "Cuenta: klo (todo en minúsculas)",
+    svcNote: "Puedes enviar SVC en el juego a la cuenta \"klo\".",
+  },
+  it: {
+    title: "Sostienici",
+    usdcTitle: "Invia USDC (Polygon)",
+    usdcAddress: "Indirizzo: 0x6CB18B7c29f84f28fA510aFFBE0fd00EFCE5e105",
+    usdcNote: "Scansiona questo QR code per inviare USDC.",
+    svcTitle: "Invia SVC in gioco",
+    svcDesc: "Account: klo (tutto in minuscolo)",
+    svcNote: "Puoi inviare SVC nel gioco all'account \"klo\".",
+  },
+  ko: {
+    title: "후원하기",
+    usdcTitle: "USDC 보내기 (Polygon)",
+    usdcAddress: "주소: 0x6CB18B7c29f84f28fA510aFFBE0fd00EFCE5e105",
+    usdcNote: "USDC를 보내려면 QR 코드를 스캔하세요.",
+    svcTitle: "게임 내 SVC 보내기",
+    svcDesc: "계정: klo (모두 소문자에 주의)",
+    svcNote: "게임에서 'klo' 계정으로 SVC를 보낼 수 있습니다.",
+  },
+};
+
+export default function SupportPage({ lang = "fr" }) {
+  const t = LABELS[lang] || LABELS.fr;
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-12">
+      <h1 className="text-3xl font-bold text-center">{t.title}</h1>
+      <section className="space-y-2 text-center">
+        <h2 className="text-xl font-semibold">{t.usdcTitle}</h2>
+        <p className="break-all">{t.usdcAddress}</p>
+        <p>{t.usdcNote}</p>
+        <Image src="/wallet.png" alt="USDC QR" width={200} height={200} className="mx-auto" />
+      </section>
+      <section className="space-y-2 text-center">
+        <h2 className="text-xl font-semibold">{t.svcTitle}</h2>
+        <p>{t.svcDesc}</p>
+        <p>{t.svcNote}</p>
+        <Image src="/klo.png" alt="klo account" width={200} height={200} className="mx-auto" />
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add multilingual support page with USDC and SVC donation options
- link support page from navbar
- remove placeholder wallet QR image

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68acd3a077a8832dbfb5e6cdbb542387