### PR TITLE
Enable horizontal scrolling on ROI tables

### DIFF
--- a/components/pages/RoiPage.js
+++ b/components/pages/RoiPage.js
@@ -978,7 +978,7 @@ const renderDrawer = (clubId) => {
             {clubs.length === 0 ? (
               <div className="text-gray-400">{t.noClubs}</div>
             ) : (
-              <div className="rounded-xl border border-gray-700 overflow-hidden">
+              <div className="rounded-xl border border-gray-700 overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead className="bg-gray-800 text-gray-300">
                     <tr>
@@ -1079,7 +1079,7 @@ const renderDrawer = (clubId) => {
             {players.length === 0 ? (
               <div className="text-gray-400">{t.noPlayers}</div>
             ) : (
-              <div className="rounded-xl border border-gray-700 overflow-hidden">
+              <div className="rounded-xl border border-gray-700 overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead className="bg-gray-800 text-gray-300">
                     <tr>


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for club and player ROI tables to improve mobile usability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad32a116c0832d93a62c8c1747faf5